### PR TITLE
Fixed a single-click activation bug for Linux platform

### DIFF
--- a/src/Local.cpp
+++ b/src/Local.cpp
@@ -24,9 +24,11 @@
 *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 *
 =========================================================================*/
+
 #include "Interface.h"
 #include <QApplication>
 
+#ifdef Q_OS_LINUX
 class DoubleClickStyle : public QProxyStyle
 {
 public:
@@ -38,6 +40,7 @@ public:
 		return QProxyStyle::styleHint(hint, option, widget, returnData);
 	}
 };
+#endif /* Q_OS_LINUX */
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
在KDE下程序有个很麻烦的BUG...即在文件选择和搜索结果里选择条目时都是单击即确认...而不是通常设置的双击确认...

貌似是KDE4与Qt5之间的兼容性问题...用了一个小Hack来绕过他...真正完全解决恐怕还是得坐等KDE5
