### PR TITLE
fix(VPlayer.cpp): 变量名time与标准库冲突

### DIFF
--- a/src/Player/VPlayer.cpp
+++ b/src/Player/VPlayer.cpp
@@ -10,7 +10,7 @@
 
 namespace
 {
-	QMutex time;
+	QMutex time_qmutex;
 
 	class PixelBuffer : public ABuffer
 	{
@@ -184,11 +184,11 @@ namespace
 
 	void mid(const libvlc_event_t *, void *)
 	{
-		if (::time.tryLock()) {
+		if (time_qmutex.tryLock()) {
 			QMetaObject::invokeMethod(lApp->findObject<APlayer>(),
 				"timeChanged",
 				Q_ARG(qint64, lApp->findObject<APlayer>()->getTime()));
-			::time.unlock();
+			time_qmutex.unlock();
 		}
 	}
 
@@ -392,11 +392,11 @@ void VPlayer::setTime(qint64 _time)
 			}
 		}
 		else{
-			::time.lock();
+			time_qmutex.lock();
 			qApp->processEvents();
 			emit jumped(_time);
 			libvlc_media_player_set_time(mp, qBound<qint64>(0, _time, getDuration()));
-			::time.unlock();
+			time_qmutex.unlock();
 		}
 	}
 }


### PR DESCRIPTION
在现在的编译器中，变量名time与标准库冲突。

以将其修改为 `time_qmutex` 以保证编译通过。

Fixes #68